### PR TITLE
AdPageLayoutFormField updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
+# ignore jetbrains ide files
+.idea
+
+# ignore dependencies
 /node_modules
+

--- a/readme.md
+++ b/readme.md
@@ -234,9 +234,13 @@ BREAD Json Option for this field:
     "style_classes": "col-md-3"
 }
 ```
-Where: **layout_fields** - list of model (bread) fields available for a selection.
+
+**layout_fields** - list of model (bread) fields available for a selection.
+
 **block_model** - block model class used for retrieve block content records.  If param is not present, the block model select input will not be displayed on the edit/add views.
+
 **form_model** - form model class used for retrieve form content records.  If param is not present, the form model select input will not be displayed on the edit/add views;
+
 **style_classes** - additional style classes to be applied to the select input fields on the edit/add views.  Default value: `col-md-4`.
 
 Rendering the field:

--- a/readme.md
+++ b/readme.md
@@ -9,11 +9,11 @@ The package extends the original [Voyager Admin Panel](https://github.com/the-co
 ## Features
 
 - Integration of [laravel-medialibrary](https://docs.spatie.be/laravel-medialibrary/) by Spatie
-- New field: VE Image, supports Title and Alt field. 
+- New field: VE Image, supports Title and Alt field.
 - New field: VE Media Files (including images), supports Sorting and unlimited attached custom fields with different types.
 - New field: VE Select Dropdown Tree. Dropdown selection for Tree type structures (with parent_id).
 - New field: VE Fields Group. JSON kind group of fields inside the one model field.
-- New field: VE Page Layout. Allows to organize layout of widgets and content on a Page. Depends on Voyager Site package. 
+- New field: VE Page Layout. Allows to organize layout of widgets and content on a Page. Depends on Voyager Site package.
 - New extended Browse Bread appearance and options.
 - Custom Browse columns order.
 - Tabs Layout for an add-edit BREAD mode.
@@ -94,7 +94,7 @@ use Spatie\MediaLibrary\HasMedia\HasMediaTrait;
 
 class Article extends Model implements HasMedia
 {
-   use HasMediaTrait;    
+   use HasMediaTrait;
 }
 
 ```
@@ -113,11 +113,11 @@ The field utilize **laravel-medialibrary** package to store single image. In add
 
 >### Field: VE Media Files
 
-This field represents **laravel-medialibrary** collection with subsets of additional custom fields. Uses to store any media files. 
-The collection can be sorted as you need using drag and drop. Select and group removing is implemented. 
+This field represents **laravel-medialibrary** collection with subsets of additional custom fields. Uses to store any media files.
+The collection can be sorted as you need using drag and drop. Select and group removing is implemented.
 
-By default it keeps two fields - **Title** and **Alt**. Changing a file inside a collection element is allowed. 
-You can use the field like a collection of widgets or just like a sortable image collection. 
+By default it keeps two fields - **Title** and **Alt**. Changing a file inside a collection element is allowed.
+You can use the field like a collection of widgets or just like a sortable image collection.
 Elements of media collection can hold additional content fields using **BREAD Json Options**.
 
 
@@ -136,7 +136,7 @@ Elements of media collection can hold additional content fields using **BREAD Js
         "link": {
             "type": "text",
             "title": "URL"
-        }        
+        }
     }
 }
 ```
@@ -151,7 +151,7 @@ By default uses "image/*" template.
 ![VE Media Files](/docs/images/adv-media-files.png)
 
 > Retrieving field data on frontend side.
- 
+
 You can use any method provided by laravel-medialibrary package. The field name of is represented media gallery name.
 
 ```php
@@ -159,12 +159,12 @@ $image = $post->getFirstMedia('field_name');
 $imageUrl = $image->getFullUrl();
 $imageTitle = $image->getCustomProperty('title');
 $imageAlt = $image->getCustomProperty('alt');
-``` 
+```
 More details see in the original [laravel-medialibrary documentation](https://docs.spatie.be/laravel-medialibrary/v7/basic-usage/retrieving-media/).
 
 >### Field: VE Fields Group
 
-Is a simple JSON like fieldset. Support three field subtypes inside: text, number and textarea. 
+Is a simple JSON like fieldset. Support three field subtypes inside: text, number and textarea.
 Useful when you need implement the same group fields in different models.
 ![Fields Group](/docs/images/fields-group.png)
 
@@ -187,7 +187,7 @@ BREAD Json Options:
     }
 }
 ```
-  
+
 Retrieving data:
 ```blade
 @if($seo = json_decode($Post->seo->fields))
@@ -207,7 +207,7 @@ BREAD Json Options (Post model, category_id field):
         "label": "title"
     }
 }
-```   
+```
 In a Post model add:
 ```php
 public function categoryId()
@@ -230,12 +230,14 @@ BREAD Json Option for this field:
         "content": "Content"
     },
     "block_model": "MonstreX\\VoyagerSite\\Models\\Block",
-    "form_model": "MonstreX\\VoyagerSite\\Models\\Form"
+    "form_model": "MonstreX\\VoyagerSite\\Models\\Form",
+    "style_classes": "col-md-3"
 }
-```   
+```
 Where: **layout_fields** - list of model (bread) fields available for a selection.
-**block_model** - block model class used for retrieve block content records. 
-**form_model** - form model class used for retrieve form content records.
+**block_model** - block model class used for retrieve block content records.  If param is not present, the block model select input will not be displayed on the edit/add views.
+**form_model** - form model class used for retrieve form content records.  If param is not present, the form model select input will not be displayed on the edit/add views;
+**style_classes** - additional style classes to be applied to the select input fields on the edit/add views.  Default value: `col-md-4`.
 
 Rendering the field:
 ```blade
@@ -251,22 +253,22 @@ New TREE browse mode implemented. If you have the field **parent_id** you can ad
 {
     "browse_tree": true
 }
-``` 
+```
 The tree mode looks similar to the menu tree view.
 
 ![Tree mode](/docs/images/tree-view.png)
- 
+
 You can use option **browse_tree_push_right** to push browsed fields to the right part of the view line.
 ```json
 {
     "browse_tree_push_right": true
 }
-``` 
+```
 All browsed fields after this field will push right.
 
 ### Alternate browse title
 
-Just replaces default bread field title with a provided option title: 
+Just replaces default bread field title with a provided option title:
 
 ```json
 {
@@ -276,8 +278,8 @@ Just replaces default bread field title with a provided option title:
 
 ### Inline checkbox switcher
 
-Using **browse_inline_checkbox** you can enable an inline switcher in a browse view mode. 
-After that you can change the field value directly (by clicking on it) from a browse mode without entering an edit mode. 
+Using **browse_inline_checkbox** you can enable an inline switcher in a browse view mode.
+After that you can change the field value directly (by clicking on it) from a browse mode without entering an edit mode.
 
 ![Inline checkbox switcher](/docs/images/inline-checkbox.png)
 
@@ -288,17 +290,17 @@ After that you can change the field value directly (by clicking on it) from a br
     "off": "Disabled",
     "checked": true
 }
-``` 
+```
 
 ### Action on a field click
 
-If you add this option *url* you will be able to call appropriate action for the record using just a click on it. 
-For an instance let it be field **Title** 
+If you add this option *url* you will be able to call appropriate action for the record using just a click on it.
+For an instance let it be field **Title**
 ```json
 {
     "url": "edit"
 }
-``` 
+```
 
 ### Column width, align and font size
 Sets width, align and font-size for the column in browse mode:
@@ -308,7 +310,7 @@ Sets width, align and font-size for the column in browse mode:
     "browse_align": "right",
     "browse_font_size": "0.8em"
 }
-``` 
+```
 
 ### Column order
 
@@ -317,7 +319,7 @@ Now you can change the column order in a browse mode using this option:
 {
     "browse_order": 1
 }
-``` 
+```
 
 ### Image max height in a row
 
@@ -326,7 +328,7 @@ Sets maximal height of thumbnail images:
 {
     "browse_image_max_height": "30px"
 }
-``` 
+```
 
 ### Section separator
 
@@ -335,7 +337,7 @@ This option makes a visual section separator line.
 {
     "section": "Media files"
 }
-``` 
+```
 
 ### Tabs layout for add-edit mode
 
@@ -347,13 +349,13 @@ In add-edit BREAD mode you can use Tabbed layout. Just put the option **tab_titl
 {
     "tab_title": "Media"
 }
-``` 
+```
 You don't need to make the first TAB, it'll be created automatically.
 
 Localizations
 ---
 
-New types of fields don't provide localization service used in Voyager. 
+New types of fields don't provide localization service used in Voyager.
 But you can use built-in localization helper and retrieve translated substring from a field content:
 
 ```php
@@ -361,7 +363,7 @@ $field_data = '{{en}}English title {{ru}}Russian title';
 ...
 $field_title_en = str_trans($field_data);
 $field_title_ru = str_trans($field_data,'ru');
-``` 
+```
 
 ## Security
 

--- a/resources/views/formfields/adv_page_layout.blade.php
+++ b/resources/views/formfields/adv_page_layout.blade.php
@@ -37,7 +37,8 @@
         </div>
     </div>
     <div class="row">
-        <div class="form-group  col-md-4 select-holder">
+         @isset($options->layout_fields)
+            <div class="form-group select-holder {{ $options->style_classes ?? 'col-md-4' }}">
             <span class="select-label">@lang('voyager-extension::bread.adv_page_layout.field_title')</span>
             <select class="form-control select2" name="fields_list" data-type="Field" data-icon="voyager-receipt">
                 <optgroup label="@lang('voyager-extension::bread.adv_page_layout.available_content_fields')">
@@ -50,7 +51,10 @@
                 <i class="voyager-plus"></i>
             </a>
         </div>
-        <div class="form-group  col-md-4 select-holder">
+        @endisset
+
+        @isset($blocks)
+            <div class="form-group select-holder {{ $options->style_classes ?? 'col-md-4' }}">
             <span class="select-label">@lang('voyager-extension::bread.adv_page_layout.block_title')</span>
             <select class="form-control select2" name="block_list" data-type="Block" data-icon="voyager-puzzle">
                 <optgroup label="@lang('voyager-extension::bread.adv_page_layout.available_blocks')">
@@ -63,18 +67,22 @@
                 <i class="voyager-plus"></i>
             </a>
         </div>
-        <div class="form-group  col-md-4 select-holder">
+        @endisset
+
+        @isset($forms)
+            <div class="form-group select-holder {{ $options->style_classes ?? 'col-md-4' }}">
             <span class="select-label">@lang('voyager-extension::bread.adv_page_layout.form_title')</span>
             <select class="form-control select2" name="form_list" data-type="Form" data-icon="voyager-window-list">
                 <optgroup label="@lang('voyager-extension::bread.adv_page_layout.available_forms')">
-                    @foreach($forms as $key => $form)
-                        <option value="{{ $form['key'] }}" >{{ $form['title'] }} ({{ $form['key'] }})</option>
-                    @endforeach
+                        @foreach($forms as $key => $form)
+                            <option value="{{ $form['key'] }}" >{{ $form['title'] }} ({{ $form['key'] }})</option>
+                        @endforeach
                 </optgroup>
             </select>
             <a href="javascript:;" title="@lang('voyager-extension::bread.adv_page_layout.add_form_section')" class="btn btn-sm btn-success add-layout-section">
                 <i class="voyager-plus"></i>
             </a>
         </div>
+        @endisset
     </div>
 </div>

--- a/src/FormFields/AdvPageLayoutFormField.php
+++ b/src/FormFields/AdvPageLayoutFormField.php
@@ -14,20 +14,27 @@ class AdvPageLayoutFormField extends AbstractHandler
      */
     public function createContent($row, $dataType, $dataTypeContent, $options)
     {
+        if (isset($options->block_model)) {
+            $model  = app( $options->block_model );
+            $blocks = $model::where( 'status', 1 )->select( 'title', 'key' )->orderBy( 'order', 'asc' )->get()->toArray();
+        }
 
-        $model = app($options->block_model);
-        $blocks = $model::where('status',1)->select('title','key')->orderBy('order', 'asc')->get()->toArray();
+		if (isset($options->form_model)) {
+			$model = app($options->form_model);
+			$forms = $model
+				::where('status', 1)
+				->select('title', 'key')
+				->get()
+				->toArray();
+		}
 
-        $model = app($options->form_model);
-        $forms = $model::where('status',1)->select('title','key')->get()->toArray();
-
-        return view('voyager-extension::formfields.adv_page_layout', [
+		return view('voyager-extension::formfields.adv_page_layout', [
             'row'             => $row,
             'options'         => $options,
             'dataType'        => $dataType,
             'dataTypeContent' => $dataTypeContent,
-            'blocks'          => $blocks,
-            'forms'           => $forms,
+            'blocks'          => $blocks ?? null,
+            'forms'           => $forms ?? null,
         ]);
     }
 


### PR DESCRIPTION
- add `style_classes` options param to AdvPageLayoutFormField to allow more flexibility in styling select input dropdowns - defaults to col-md-4;
- update AdvPageLayoutFormField view to conditionally display select inputs only if the respective options fields are present;
- update AdvPageLayoutFormField class to only load block_model & form_model records if respective options params are present;
- update gitignore to ignore jetbrains ide files;
- update readme with new options and minor formatting fixes;