### PR TITLE
Display compatibility with Storage providers

### DIFF
--- a/src/Generators/MediaLibraryUrlGenerator.php
+++ b/src/Generators/MediaLibraryUrlGenerator.php
@@ -12,7 +12,7 @@ class MediaLibraryUrlGenerator extends  BaseUrlGenerator
     public function getUrl(): string
     {
 
-        $url = '/storage/' . $this->getPathRelativeToRoot();
+        $url = $this->getDisk()->url($this->getPathRelativeToRoot());
 
         $url = $this->versionUrl($url);
 


### PR DESCRIPTION
Hello, thanks for that extensions it suits perfectly my needs.

I've noticed that media library form field display on Voyager Admin doesn't work when Storage is set on S3, so here is my patch.