### PR TITLE
Tree view error. Please, update browse-tree.blade.php

### DIFF
--- a/resources/views/bread/browse-tree.blade.php
+++ b/resources/views/bread/browse-tree.blade.php
@@ -24,7 +24,7 @@
                 </div>
                 <div class="panel-body tree-items-list" style="padding:30px;">
                     <div class="dd tree-items-list">
-                        @include('voyager-extension::bread.partials.tree-list', ['items' => flat_to_tree($dataTypeContent->toArray()['data'])])
+                        @include('voyager-extension::bread.partials.tree-list', ['items' => flat_to_tree(isset($dataTypeContent->toArray()['data'])?$dataTypeContent->toArray()['data']:$dataTypeContent->toArray())])
                     </div>
                 </div>
             </div>

--- a/resources/views/bread/browse-tree.blade.php
+++ b/resources/views/bread/browse-tree.blade.php
@@ -24,7 +24,7 @@
                 </div>
                 <div class="panel-body tree-items-list" style="padding:30px;">
                     <div class="dd tree-items-list">
-                        @include('voyager-extension::bread.partials.tree-list', ['items' => flat_to_tree($dataTypeContent->toArray())])
+                        @include('voyager-extension::bread.partials.tree-list', ['items' => flat_to_tree($dataTypeContent->toArray()['data'])])
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Tree display causes an error. index 0 not found. 
Please apply changes to the repository

Sometime $dataTypeContent->toArray() return clean array with items ['0'=>...
Sometime there is subitem ['data']=>['0'=>...

It is looks like bug, so this fix will close both cases